### PR TITLE
Fix runtime syntax warning

### DIFF
--- a/hocr_spec/validate.py
+++ b/hocr_spec/validate.py
@@ -56,7 +56,7 @@ class HocrValidator(object):
 
         def add(self, level, *args, **kwargs):
             self.items.append(HocrValidator.ReportItem(level, *args, **kwargs))
-            if level is 'FATAL':
+            if level == 'FATAL':
                 raise ValueError("Validation hit a FATAL issue: %s" % self.items[-1])
 
         def is_valid(self):


### PR DESCRIPTION
Python 3.11 reported a warning:

    hocr_spec/validate.py:59: SyntaxWarning: "is" with a literal. Did you mean "=="?